### PR TITLE
Schedule job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - OddJob.Example updated to dotnetcore 2
 - OddJob.Tests updated to dotnetcore 2 and xunit 2.3
 
+### Added
+- Running jobs on a schedule
+
 ## [0.1.1](#0.1.1) - 2017-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# OddJob
+# OddJob
 
 [![Build status](https://ci.appveyor.com/api/projects/status/k6vu2qps4akst6cj/branch/master?svg=true)](https://ci.appveyor.com/project/lukesmith/oddjob/branch/master)
 [![NuGet](http://img.shields.io/nuget/v/OddJob.svg)](https://www.nuget.org/packages/OddJob/)
@@ -6,7 +6,7 @@
 OddJob was born out of the need to run both a long running process and a HttpServer within a single command line application,
 along with handling graceful shutdown of the process when signalled by the OS.
 
-Unhandled exceptions by any job will signal a cancellation to all jobs to gracefully end, eventually exiting the process.
+Unhandled exceptions by jobs (with the exception of scheduled jobs) will signal a cancellation to all jobs to gracefully end, eventually exiting the process.
 
 ## Example
 
@@ -35,6 +35,46 @@ public class BackgroundJob : OddJob.Jobs.Forever
         Console.WriteLine("tick");
 
         await Task.Delay(1000);
+    }
+}
+```
+
+Jobs can be run on a schedule. Schedules can be implement using the `ISchedule` interface
+
+```csharp
+class Program
+{
+    static int Main(string[] args)
+    {
+        using (var loggerFactory = new LoggerFactory())
+        {
+            loggerFactory.AddConsole();
+
+            var builder = new OddJob.JobHostBuilder()
+                .Add(() => new MyJob(loggerFactory), Schedule.Every().Hour())
+                .UseLoggerFactory(loggerFactory);
+
+            return builder.BuildAndRun();
+        }
+    }
+}
+
+public class MyJob : IJob
+{
+    private readonly ILoggerFactory loggerFactory;
+
+    public MyJob(ILoggerFactory loggerFactory)
+    {
+        this.loggerFactory = loggerFactory;
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        var logger = this.loggerFactory.CreateLogger<OneTimeJob>();
+
+        logger.LogInformation("tick");
+
+        await Task.CompletedTask;
     }
 }
 ```

--- a/src/OddJob.Example/OddJob.Example.csproj
+++ b/src/OddJob.Example/OddJob.Example.csproj
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="GlobalSuppressions.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <AdditionalFiles Include="$(SolutionDir)\.stylecop\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 

--- a/src/OddJob.Example/Program.cs
+++ b/src/OddJob.Example/Program.cs
@@ -16,12 +16,12 @@ namespace OddJob.Example
                 loggerFactory.AddConsole();
 
                 var builder = new JobHostBuilder()
+                    .Add(() => new FailingBackgroundJob(loggerFactory), Schedule.Every().Second())
                     .Add(() => new OneTimeJob(loggerFactory), Schedule.Every().Second())
                     .Add(() => new OneTimeJob(loggerFactory), Schedule.Every().Minute())
                     .Add(() => new OneTimeJob(loggerFactory), Schedule.Every().Hour())
                     .Add(() => new OneTimeJob(loggerFactory), Schedule.Every().Day().At(12, 3, 1))
                     .Add(() => new OneTimeJob(loggerFactory))
-                    .Add(() => new FailingBackgroundJob(loggerFactory))
                     .Add(() => new BackgroundJob(loggerFactory))
                     .Add(() => new WebServer(configuration, loggerFactory))
                     .UseLoggerFactory(loggerFactory);

--- a/src/OddJob.Example/Program.cs
+++ b/src/OddJob.Example/Program.cs
@@ -1,5 +1,7 @@
+using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using OddJob.Schedules;
 
 namespace OddJob.Example
 {
@@ -15,6 +17,7 @@ namespace OddJob.Example
                 loggerFactory.AddConsole();
 
                 var builder = new JobHostBuilder()
+                    .Add(() => new OneTimeJob(loggerFactory), new EveryTenSeconds())
                     .Add(() => new OneTimeJob(loggerFactory))
                     .Add(() => new FailingBackgroundJob(loggerFactory))
                     .Add(() => new BackgroundJob(loggerFactory))
@@ -22,6 +25,15 @@ namespace OddJob.Example
                     .UseLoggerFactory(loggerFactory);
 
                 return builder.BuildAndRun();
+            }
+        }
+
+        private class EveryTenSeconds : ISchedule
+        {
+            public DateTime Next(DateTime from)
+            {
+                var a = from.Second % 10;
+                return from.AddSeconds(10 - a);
             }
         }
     }

--- a/src/OddJob.Example/Program.cs
+++ b/src/OddJob.Example/Program.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using OddJob.Schedules;
@@ -17,7 +16,10 @@ namespace OddJob.Example
                 loggerFactory.AddConsole();
 
                 var builder = new JobHostBuilder()
-                    .Add(() => new OneTimeJob(loggerFactory), new EveryTenSeconds())
+                    .Add(() => new OneTimeJob(loggerFactory), Schedule.Every().Second())
+                    .Add(() => new OneTimeJob(loggerFactory), Schedule.Every().Minute())
+                    .Add(() => new OneTimeJob(loggerFactory), Schedule.Every().Hour())
+                    .Add(() => new OneTimeJob(loggerFactory), Schedule.Every().Day().At(12, 3, 1))
                     .Add(() => new OneTimeJob(loggerFactory))
                     .Add(() => new FailingBackgroundJob(loggerFactory))
                     .Add(() => new BackgroundJob(loggerFactory))
@@ -25,15 +27,6 @@ namespace OddJob.Example
                     .UseLoggerFactory(loggerFactory);
 
                 return builder.BuildAndRun();
-            }
-        }
-
-        private class EveryTenSeconds : ISchedule
-        {
-            public DateTime Next(DateTime from)
-            {
-                var a = from.Second % 10;
-                return from.AddSeconds(10 - a);
             }
         }
     }

--- a/src/OddJob/Clock.cs
+++ b/src/OddJob/Clock.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OddJob.Tests")]
+
+namespace OddJob
+{
+#pragma warning disable SA1600 // Elements should be documented
+    internal sealed class Clock : IClock
+    {
+        public static readonly IClock DefaultClock = new Clock();
+
+        private readonly Func<DateTime> get = () => DateTime.UtcNow;
+
+        public Clock()
+        {
+        }
+
+        public Clock(Func<DateTime> timeFunc)
+        {
+            this.get = timeFunc;
+        }
+
+        public DateTime UtcNow => this.get();
+    }
+#pragma warning restore SA1600 // Elements should be documented
+}

--- a/src/OddJob/IClock.cs
+++ b/src/OddJob/IClock.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace OddJob
+{
+#pragma warning disable SA1600 // Elements should be documented
+    internal interface IClock
+    {
+        DateTime UtcNow { get; }
+    }
+#pragma warning restore SA1600 // Elements should be documented
+}

--- a/src/OddJob/JobExtensions.cs
+++ b/src/OddJob/JobExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace OddJob
+{
+#pragma warning disable SA1600 // Elements should be documented
+    internal static class JobExtensions
+    {
+        public static string GetName(this IJob job)
+        {
+            return GetName(job.GetType());
+        }
+
+        public static string GetName(Type jobType)
+        {
+            var attribute = jobType.GetTypeInfo().GetCustomAttributes<NameAttribute>().FirstOrDefault();
+            if (attribute == null)
+            {
+                return jobType.Name;
+            }
+
+            return attribute.GetName();
+        }
+    }
+#pragma warning restore SA1600 // Elements should be documented
+}

--- a/src/OddJob/JobHost.cs
+++ b/src/OddJob/JobHost.cs
@@ -145,7 +145,7 @@ namespace OddJob
             try
             {
                 Task.WaitAll(this.jobs.Select(job => RunJobAsync(job, cts)
-                    .ContinueWith(this.LogTaskCompletation, job)).ToArray());
+                    .ContinueWith((task, state) => this.LogTaskCompletation(task, state as IJob), job)).ToArray());
 
                 await Task.CompletedTask;
             }
@@ -185,9 +185,9 @@ namespace OddJob
             }
         }
 
-        private void LogTaskCompletation(Task completedTask, object state)
+        private void LogTaskCompletation(Task completedTask, IJob job)
         {
-            var jobName = state.GetType().Name;
+            var jobName = job.GetName();
 
             if (completedTask.IsCanceled)
             {

--- a/src/OddJob/JobHostBuilder.cs
+++ b/src/OddJob/JobHostBuilder.cs
@@ -83,16 +83,14 @@ namespace OddJob
         /// Add a callback to create a <see cref="IJob"/> that will be managed by
         /// a <see cref="IJobHost"/> built by <see cref="JobHostBuilder"/>.
         /// </summary>
+        /// <typeparam name="T">The type of the <see cref="IJob"/> to add.</typeparam>
         /// <param name="factory">A function that creates an <see cref="IJob"/>.</param>
         /// <param name="schedule">The <see cref="ISchedule"/> on which the <paramref name="factory"/> <see cref="IJob"/> will run.</param>
         /// <returns>A <see cref="JobHostBuilder"/>.</returns>
-        public JobHostBuilder Add(Func<IJob> factory, ISchedule schedule)
+        public JobHostBuilder Add<T>(Func<T> factory, ISchedule schedule)
+            where T : IJob
         {
-            this.processes.Add(() =>
-            {
-                var job = factory();
-                return new Jobs.ScheduledJob(job, schedule, this.loggerFactory, Clock.DefaultClock);
-            });
+            this.processes.Add(() => new Jobs.ScheduledJob<T>(factory, schedule, this.loggerFactory, Clock.DefaultClock));
 
             return this;
         }

--- a/src/OddJob/JobHostBuilder.cs
+++ b/src/OddJob/JobHostBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using OddJob.Schedules;
 
 namespace OddJob
 {
@@ -12,7 +13,7 @@ namespace OddJob
     {
         private readonly IList<Func<IJob>> processes = new List<Func<IJob>>();
 
-        private ILoggerFactory loggerFactory;
+        private ILoggerFactory loggerFactory = NullLoggerFactory.Instance;
 
         /// <summary>
         /// Creates an instance of <typeparamref name="T"/> that will be managed
@@ -24,6 +25,20 @@ namespace OddJob
             where T : IJob, new()
         {
             this.Add(() => new T());
+            return this;
+        }
+
+        /// <summary>
+        /// Creates an instance of <typeparamref name="T"/> that will be managed
+        /// by the <see cref="IJobHost"/> built by <see cref="JobHostBuilder"/> and run on a <paramref name="schedule"/>.
+        /// </summary>
+        /// <typeparam name="T">An <see cref="IJob"/> to add to the built <see cref="JobHost"/>.</typeparam>
+        /// <param name="schedule">The <see cref="ISchedule"/> on which the <typeparamref name="T"/> will run.</param>
+        /// <returns>A <see cref="JobHostBuilder"/>.</returns>
+        public JobHostBuilder Add<T>(ISchedule schedule)
+            where T : IJob, new()
+        {
+            this.Add(() => new T(), schedule);
             return this;
         }
 
@@ -40,6 +55,19 @@ namespace OddJob
         }
 
         /// <summary>
+        /// Add a <see cref="IJob"/> instance that will be managed by
+        /// a <see cref="IJobHost"/> built by <see cref="JobHostBuilder"/>.
+        /// </summary>
+        /// <param name="job">A <see cref="IJob"/>.</param>
+        /// <param name="schedule">The <see cref="ISchedule"/> on which the <paramref name="job"/> will run.</param>
+        /// <returns>A <see cref="JobHostBuilder"/>.</returns>
+        public JobHostBuilder Add(IJob job, ISchedule schedule)
+        {
+            this.Add(() => job, schedule);
+            return this;
+        }
+
+        /// <summary>
         /// Add a callback to create a <see cref="IJob"/> that will be managed by
         /// a <see cref="IJobHost"/> built by <see cref="JobHostBuilder"/>.
         /// </summary>
@@ -48,6 +76,24 @@ namespace OddJob
         public JobHostBuilder Add(Func<IJob> factory)
         {
             this.processes.Add(factory);
+            return this;
+        }
+
+        /// <summary>
+        /// Add a callback to create a <see cref="IJob"/> that will be managed by
+        /// a <see cref="IJobHost"/> built by <see cref="JobHostBuilder"/>.
+        /// </summary>
+        /// <param name="factory">A function that creates an <see cref="IJob"/>.</param>
+        /// <param name="schedule">The <see cref="ISchedule"/> on which the <paramref name="factory"/> <see cref="IJob"/> will run.</param>
+        /// <returns>A <see cref="JobHostBuilder"/>.</returns>
+        public JobHostBuilder Add(Func<IJob> factory, ISchedule schedule)
+        {
+            this.processes.Add(() =>
+            {
+                var job = factory();
+                return new Jobs.ScheduledJob(job, schedule, this.loggerFactory, Clock.DefaultClock);
+            });
+
             return this;
         }
 
@@ -68,7 +114,7 @@ namespace OddJob
         /// <returns>A <see cref="JobHostBuilder"/>.</returns>
         public IJobHost Build()
         {
-            return new JobHost(this.processes.Select(x => x()).ToArray(), this.loggerFactory ?? new NullLoggerFactory());
+            return new JobHost(this.processes.Select(x => x()).ToArray(), this.loggerFactory);
         }
     }
 }

--- a/src/OddJob/JobHostExtensions.cs
+++ b/src/OddJob/JobHostExtensions.cs
@@ -66,7 +66,7 @@ namespace OddJob
             {
                 foreach (var job in host.Jobs)
                 {
-                    Console.WriteLine($"Running job - {job.GetType().Name}");
+                    Console.WriteLine($"Running job - {job.GetName()}");
                 }
 
                 await host.StartAsync(cts);

--- a/src/OddJob/Jobs/ScheduledJob.cs
+++ b/src/OddJob/Jobs/ScheduledJob.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using OddJob.Schedules;
+
+namespace OddJob.Jobs
+{
+    /// <summary>
+    /// Represents a <see cref="IJob"/> that runs on a schedule, or
+    /// until the host process ends.
+    /// </summary>
+    internal class ScheduledJob : IJob, IDisposable
+    {
+        private readonly IJob job;
+        private readonly ILogger logger;
+        private readonly ISchedule schedule;
+        private readonly IClock clock;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScheduledJob"/> class.
+        /// </summary>
+        /// <param name="job">The <see cref="IJob"/> to run on the <paramref name="schedule"/>.</param>
+        /// <param name="schedule">The <see cref="ISchedule"/> to use to run the <paramref name="job"/>.</param>
+        /// <param name="loggerFactory">A <see cref="ILoggerFactory"/>.</param>
+        /// <param name="clock">A reference to the <see cref="IClock"/> to use for scheduling.</param>
+        public ScheduledJob(IJob job, ISchedule schedule, ILoggerFactory loggerFactory, IClock clock)
+        {
+            this.job = job;
+            this.logger = loggerFactory.CreateLogger<ScheduledJob>();
+            this.schedule = schedule;
+            this.clock = clock;
+        }
+
+        /// <inheritdoc />
+        public async Task RunAsync(CancellationToken cancellationToken)
+        {
+            var jobType = this.job.GetType().Name;
+
+            while (true)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                var next = this.schedule.Next(this.clock.UtcNow);
+
+                var now = this.clock.UtcNow;
+                if (next >= now)
+                {
+                    var delay = next - now;
+
+                    this.logger.LogInformation("Waiting for {0} until {1}", delay, next);
+
+                    await Task.Delay(delay, cancellationToken);
+
+                    this.logger.LogInformation("Starting job {0}", jobType);
+
+                    this.job.RunAsync(cancellationToken).Wait(cancellationToken);
+
+                    this.logger.LogInformation("Worker job {0} completed", jobType);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (this.job is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+}

--- a/src/OddJob/Jobs/ScheduledJob.cs
+++ b/src/OddJob/Jobs/ScheduledJob.cs
@@ -10,24 +10,26 @@ namespace OddJob.Jobs
     /// Represents a <see cref="IJob"/> that runs on a schedule, or
     /// until the host process ends.
     /// </summary>
-    internal class ScheduledJob : IJob, INamed, IDisposable
-    [Name(nameof(ScheduledJob))]
+    /// <typeparam name="T">The type of <see cref="IJob"/> that will be run on the schedule.</typeparam>
+    [Name(nameof(ScheduledJob<T>))]
+    internal class ScheduledJob<T> : IJob
+        where T : IJob
     {
-        private readonly IJob job;
-        private readonly ILogger logger;
+        private readonly Func<T> jobFactory;
         private readonly ISchedule schedule;
+        private readonly ILoggerFactory loggerFactory;
         private readonly IClock clock;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ScheduledJob"/> class.
+        /// Initializes a new instance of the <see cref="ScheduledJob{T}"/> class.
         /// </summary>
-        /// <param name="job">The <see cref="IJob"/> to run on the <paramref name="schedule"/>.</param>
-        /// <param name="schedule">The <see cref="ISchedule"/> to use to run the <paramref name="job"/>.</param>
+        /// <param name="jobFactory">A factory to create the <see cref="IJob"/> to run on the <paramref name="schedule"/>.</param>
+        /// <param name="schedule">The <see cref="ISchedule"/> to use to run the <see cref="IJob"/>.</param>
         /// <param name="loggerFactory">A <see cref="ILoggerFactory"/>.</param>
         /// <param name="clock">A reference to the <see cref="IClock"/> to use for scheduling.</param>
-        public ScheduledJob(IJob job, ISchedule schedule, ILoggerFactory loggerFactory, IClock clock)
+        public ScheduledJob(Func<T> jobFactory, ISchedule schedule, ILoggerFactory loggerFactory, IClock clock)
         {
-            this.job = job;
+            this.jobFactory = jobFactory;
             this.schedule = schedule;
             this.loggerFactory = loggerFactory;
             this.clock = clock;
@@ -36,8 +38,6 @@ namespace OddJob.Jobs
         /// <inheritdoc />
         public async Task RunAsync(CancellationToken cancellationToken)
         {
-            var jobName = this.job.GetName();
-
             while (true)
             {
                 if (cancellationToken.IsCancellationRequested)
@@ -52,6 +52,9 @@ namespace OddJob.Jobs
                 {
                     var delay = next - now;
 
+                    var job = this.jobFactory();
+                    var jobName = job.GetName();
+
                     var logger = this.loggerFactory.CreateLogger($"{this.GetName()}:{jobName}");
                     logger.LogInformation("Waiting for {0} until {1}", delay, next);
 
@@ -59,20 +62,58 @@ namespace OddJob.Jobs
 
                     logger.LogInformation("Starting job {0}", jobName);
 
-                    this.job.RunAsync(cancellationToken).Wait(cancellationToken);
+                    try
+                    {
+                        var taskState = new TaskState
+                        {
+                            Job = job,
+                            Logger = logger,
+                        };
 
-                    this.logger.LogInformation("Worker job {0} completed", jobName);
+                        job.RunAsync(cancellationToken)
+                            .ContinueWith((task, state) => LogTaskCompletation(task, state as TaskState), taskState, cancellationToken)
+                            .Wait(cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogInformation(0, ex, $"{jobName} errored with message '{ex.Message}'");
+                    }
+                    finally
+                    {
+                        if (job is IDisposable disposable)
+                        {
+                            disposable.Dispose();
+                        }
+                    }
+
+                    logger.LogInformation("Worker job {0} completed", jobName);
                 }
             }
         }
 
-        /// <inheritdoc />
-        public void Dispose()
+        private static void LogTaskCompletation(Task completedTask, TaskState state)
         {
-            if (this.job is IDisposable disposable)
+            var jobName = state.Job.GetName();
+
+            if (completedTask.IsCanceled)
             {
-                disposable.Dispose();
+                state.Logger.LogInformation($"{jobName} was cancelled");
             }
+            else if (completedTask.IsFaulted)
+            {
+                state.Logger.LogInformation(0, completedTask.Exception, $"{jobName} faulted with message '{completedTask.Exception.Message}'");
+            }
+            else
+            {
+                state.Logger.LogInformation($"{jobName} has completed");
+            }
+        }
+
+        private class TaskState
+        {
+            public IJob Job { get; set; }
+
+            public ILogger Logger { get; set; }
         }
     }
 }

--- a/src/OddJob/NameAttribute.cs
+++ b/src/OddJob/NameAttribute.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace OddJob
+{
+    /// <summary>
+    /// Represents an <see cref="Attribute"/> for a class that has a specific name at runtime.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class NameAttribute : Attribute
+    {
+        private readonly string name;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NameAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        public NameAttribute(string name)
+        {
+            this.name = name;
+        }
+
+        /// <summary>
+        /// Gets the Name defined.
+        /// </summary>
+        /// <returns>Returns the name.</returns>
+        public string GetName()
+        {
+            return this.name;
+        }
+    }
+}

--- a/src/OddJob/NullLoggerFactory.cs
+++ b/src/OddJob/NullLoggerFactory.cs
@@ -6,6 +6,8 @@ namespace OddJob
 #pragma warning disable SA1600 // Elements should be documented
     internal sealed class NullLoggerFactory : ILoggerFactory
     {
+        public static readonly NullLoggerFactory Instance = new NullLoggerFactory();
+
         public void Dispose()
         {
         }

--- a/src/OddJob/Schedules/Daily.cs
+++ b/src/OddJob/Schedules/Daily.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace OddJob.Schedules
+{
+    /// <summary>
+    /// Represents a <see cref="ISchedule"/> that runs daily.
+    /// </summary>
+    public sealed class Daily : ISchedule
+    {
+        private readonly TimeSpan timeOfDay;
+
+#pragma warning disable SA1600 // Elements should be documented
+        internal Daily()
+#pragma warning restore SA1600 // Elements should be documented
+            : this(TimeSpan.Zero)
+        {
+        }
+
+#pragma warning disable SA1600 // Elements should be documented
+        private Daily(TimeSpan timeOfDay)
+#pragma warning restore SA1600 // Elements should be documented
+        {
+            this.timeOfDay = timeOfDay;
+        }
+
+        /// <summary>
+        /// Creates a schedule which runs daily at the specified time.
+        /// </summary>
+        /// <param name="hour">A value representing the hour of the day.</param>
+        /// <param name="minute">A value representing the minute of the <paramref name="hour"/>.</param>
+        /// <param name="second">A value representing the second within the <paramref name="minute"/>.</param>
+        /// <returns>A <see cref="Daily"/> schedule.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when either:
+        ///     <paramref name="hour"/> is outside of 0-23
+        ///     <paramref name="minute"/> is outside of 0-59
+        ///     <paramref name="second"/> is outside of 0-59
+        /// </exception>
+        public ISchedule At(int hour, int minute, int second)
+        {
+            if (hour < 0 || hour > 23)
+            {
+                throw new ArgumentOutOfRangeException(nameof(hour), hour, "Value must be within range of 0-23");
+            }
+
+            if (minute < 0 || minute > 59)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minute), hour, "Value must be within range of 0-59");
+            }
+
+            if (second < 0 || second > 59)
+            {
+                throw new ArgumentOutOfRangeException(nameof(second), hour, "Value must be within range of 0-59");
+            }
+
+            return new Daily(new TimeSpan(hour, minute, second));
+        }
+
+        /// <inheritdoc />
+        public DateTime Next(DateTime from)
+        {
+            return from.Date.AddDays(1).Add(this.timeOfDay);
+        }
+    }
+}

--- a/src/OddJob/Schedules/EveryExtensions.cs
+++ b/src/OddJob/Schedules/EveryExtensions.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace OddJob.Schedules
+{
+    /// <summary>
+    /// Extensions for <see cref="IEvery"/>.
+    /// </summary>
+    public static class EveryExtensions
+    {
+        /// <summary>
+        /// Creates a schedule which runs daily at the specified time.
+        /// </summary>
+        /// <param name="every">An <see cref="IEvery"/> instance.</param>
+        /// <returns>A <see cref="Daily"/> schedule.</returns>
+        public static Daily Day(this IEvery every) => new Daily();
+
+        /// <summary>
+        /// Creates a <see cref="ISchedule"/> of every hour.
+        /// </summary>
+        /// <param name="every">A <see cref="IEvery"/>.</param>
+        /// <returns>
+        /// A <see cref="ISchedule"/> of every hour.
+        /// </returns>
+        public static ISchedule Hour(this IEvery every) =>
+            new GenericSchedule(from => from.Date.Add(new TimeSpan(from.Hour, 0, 0)).AddHours(1));
+
+        /// <summary>
+        /// Creates a <see cref="ISchedule"/> of every minute.
+        /// </summary>
+        /// <param name="every">A <see cref="IEvery"/>.</param>
+        /// <returns>
+        /// A <see cref="ISchedule"/> of every minute.
+        /// </returns>
+        public static ISchedule Minute(this IEvery every) => new GenericSchedule(from =>
+            from.Date.Add(new TimeSpan(from.Hour, from.Minute, 0)).AddMinutes(1));
+
+        /// <summary>
+        /// Creates a <see cref="ISchedule"/> of every second.
+        /// </summary>
+        /// <param name="every">A <see cref="IEvery"/>.</param>
+        /// <returns>
+        /// A <see cref="ISchedule"/> of every second.
+        /// </returns>
+        public static ISchedule Second(this IEvery every) =>
+            new GenericSchedule(from => from.Date.Add(new TimeSpan(from.Hour, from.Minute, from.Second)).AddSeconds(1));
+    }
+}

--- a/src/OddJob/Schedules/GenericSchedule.cs
+++ b/src/OddJob/Schedules/GenericSchedule.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace OddJob.Schedules
+{
+#pragma warning disable SA1600 // Elements should be documented
+    internal class GenericSchedule : ISchedule
+    {
+        private readonly Func<DateTime, DateTime> func;
+
+        public GenericSchedule(Func<DateTime, DateTime> func)
+        {
+            this.func = func;
+        }
+
+        public static implicit operator GenericSchedule(Func<DateTime, DateTime> a)
+        {
+            return new GenericSchedule(a);
+        }
+
+        public DateTime Next(DateTime from)
+        {
+            return this.func(from);
+        }
+    }
+#pragma warning restore SA1600 // Elements should be documented
+}

--- a/src/OddJob/Schedules/IEvery.cs
+++ b/src/OddJob/Schedules/IEvery.cs
@@ -1,0 +1,9 @@
+namespace OddJob.Schedules
+{
+    /// <summary>
+    /// Defines an interface for building schedules that run on a fix period.
+    /// </summary>
+    public interface IEvery
+    {
+    }
+}

--- a/src/OddJob/Schedules/ISchedule.cs
+++ b/src/OddJob/Schedules/ISchedule.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace OddJob.Schedules
+{
+    /// <summary>
+    /// Defines the interface for a <see cref="IJob"/> schedule.
+    /// </summary>
+    public interface ISchedule
+    {
+        /// <summary>
+        /// Gets the next <see cref="DateTime"/> in the schedule after the <paramref name="from"/> value specified.
+        /// </summary>
+        /// <param name="from">A <see cref="DateTime"/>.</param>
+        /// <returns>The next <see cref="DateTime"/> in the schedule.</returns>
+        DateTime Next(DateTime from);
+    }
+}

--- a/src/OddJob/Schedules/Schedule.cs
+++ b/src/OddJob/Schedules/Schedule.cs
@@ -1,0 +1,20 @@
+namespace OddJob.Schedules
+{
+    /// <summary>
+    /// Contains builders for creating <see cref="ISchedule"/>
+    /// </summary>
+    public static class Schedule
+    {
+        /// <summary>
+        /// Create a schedule that runs on a fix period of time.
+        /// </summary>
+        /// <returns>
+        /// A reference to <see cref="IEvery"/>.
+        /// </returns>
+        public static IEvery Every() => new EveryImpl();
+
+        private sealed class EveryImpl : IEvery
+        {
+        }
+    }
+}

--- a/test/OddJob.Tests/JobExtensionsTests.cs
+++ b/test/OddJob.Tests/JobExtensionsTests.cs
@@ -1,0 +1,40 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OddJob.Tests
+{
+    public class JobExtensionsTests
+    {
+        [Fact]
+        public void ClassNotSpecifyingTheNameAttribute()
+        {
+            var result = JobExtensions.GetName(typeof(NoNameAttribute));
+            Assert.Equal("NoNameAttribute", result);
+        }
+
+        [Fact]
+        public void ClassSpecifyingTheNameAttributeWithAName()
+        {
+            var result = JobExtensions.GetName(typeof(NameAttributeWithName));
+            Assert.Equal("HelloWorld", result);
+        }
+
+        private class NoNameAttribute : IJob
+        {
+            public Task RunAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        [Name("HelloWorld")]
+        private class NameAttributeWithName : IJob
+        {
+            public Task RunAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/test/OddJob.Tests/ScheduledJobTests.cs
+++ b/test/OddJob.Tests/ScheduledJobTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OddJob.Jobs;
+using OddJob.Schedules;
+using Xunit;
+
+namespace OddJob.Tests
+{
+    public class ScheduledJobTests
+    {
+        [Fact]
+        public async Task WaitsForScheduleBeforeRunningWrappedJob()
+        {
+            var clock = Clock.DefaultClock;
+
+            using (var cts = new CancellationTokenSource())
+            {
+                var job = new FakeJob(cts, clock);
+
+                var fakeSchedule = new FakeSchedule();
+                var scheduledJob = new ScheduledJob(job, fakeSchedule, NullLoggerFactory.Instance, clock);
+
+                var timeBefore = clock.UtcNow;
+
+                await Assert.ThrowsAsync<OperationCanceledException>(() => scheduledJob.RunAsync(cts.Token));
+
+                Assert.True(job.RunTime.Subtract(timeBefore) >= TimeSpan.FromSeconds(2));
+            }
+        }
+
+        [Fact]
+        public void DisposesWrappedJob()
+        {
+            var job = new DisposableJob();
+            var scheduledJob = new ScheduledJob(job, new FakeSchedule(), NullLoggerFactory.Instance, Clock.DefaultClock);
+
+            scheduledJob.Dispose();
+
+            Assert.Equal(1, job.DisposedCalls);
+        }
+
+        private class DisposableJob : IJob, IDisposable
+        {
+            public int DisposedCalls { get; private set; }
+
+            public Task RunAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+
+            public void Dispose()
+            {
+                this.DisposedCalls += 1;
+            }
+        }
+
+        private class FakeJob : IJob
+        {
+            private readonly CancellationTokenSource cts;
+            private readonly IClock clock;
+
+            public FakeJob(CancellationTokenSource cts, IClock clock)
+            {
+                this.cts = cts;
+                this.clock = clock;
+            }
+
+            public DateTime RunTime { get; private set; }
+
+            public Task RunAsync(CancellationToken cancellationToken)
+            {
+                this.RunTime = this.clock.UtcNow;
+
+                this.cts.Cancel();
+
+                return Task.CompletedTask;
+            }
+        }
+
+        private class FakeSchedule : ISchedule
+        {
+            public DateTime Next(DateTime @from)
+            {
+                return @from.AddSeconds(2);
+            }
+        }
+    }
+}

--- a/test/OddJob.Tests/Schedules/DailyTests.cs
+++ b/test/OddJob.Tests/Schedules/DailyTests.cs
@@ -1,0 +1,61 @@
+using System;
+using OddJob.Schedules;
+using Xunit;
+
+namespace OddJob.Tests.Schedules
+{
+    public class DailyTests
+    {
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(24)]
+        public void HourOutsideOfAllowedRange(int hour)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Daily().At(hour, 0, 0));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(60)]
+        public void MinuteOutsideOfAllowedRange(int minute)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Daily().At(0, minute, 0));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(60)]
+        public void SecondOutsideOfAllowedRange(int second)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Daily().At(0, 0, second));
+        }
+
+        [Theory]
+#pragma warning disable xUnit1010 // The value is not convertible to the method parameter type
+        [InlineData("2017-01-02T03:04:00", "2017-01-03T00:00:00")]
+        [InlineData("2017-01-02T00:00:00", "2017-01-03T00:00:00")]
+#pragma warning restore xUnit1010 // The value is not convertible to the method parameter type
+        public void EveryDay(DateTime from, DateTime expected)
+        {
+            var schedule = Schedule.Every().Day();
+
+            var result = schedule.Next(from);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+#pragma warning disable xUnit1010 // The value is not convertible to the method parameter type
+        [InlineData("2017-01-02T03:04:00", "2017-01-03T11:32:34")]
+        [InlineData("2017-01-02T00:00:00", "2017-01-03T11:32:34")]
+#pragma warning restore xUnit1010 // The value is not convertible to the method parameter type
+        public void EveryDayAt(DateTime from, DateTime expected)
+        {
+            var schedule = Schedule.Every().Day().At(11, 32, 34);
+
+            var result = schedule.Next(from);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/test/OddJob.Tests/Schedules/EveryHourTests.cs
+++ b/test/OddJob.Tests/Schedules/EveryHourTests.cs
@@ -1,0 +1,27 @@
+using System;
+using OddJob.Schedules;
+using Xunit;
+
+namespace OddJob.Tests.Schedules
+{
+    public class EveryHourTests
+    {
+        [Theory]
+#pragma warning disable xUnit1010 // The value is not convertible to the method parameter type
+        [InlineData("2017-01-02T03:04:00", "2017-01-02T04:00:00")]
+        [InlineData("2017-01-02T03:04:05", "2017-01-02T04:00:00")]
+        [InlineData("2017-01-02T03:59:59", "2017-01-02T04:00:00")]
+        [InlineData("2017-01-02T03:00:01", "2017-01-02T04:00:00")]
+        [InlineData("2017-01-02T23:00:01", "2017-01-03T00:00:00")]
+        [InlineData("2017-01-31T23:00:01", "2017-02-01T00:00:00")]
+#pragma warning restore xUnit1010 // The value is not convertible to the method parameter type
+        public void Every(DateTime from, DateTime expected)
+        {
+            var schedule = Schedule.Every().Hour();
+
+            var result = schedule.Next(from);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/test/OddJob.Tests/Schedules/EveryMinuteTests.cs
+++ b/test/OddJob.Tests/Schedules/EveryMinuteTests.cs
@@ -1,0 +1,26 @@
+using System;
+using OddJob.Schedules;
+using Xunit;
+
+namespace OddJob.Tests.Schedules
+{
+    public class EveryMinuteTests
+    {
+        [Theory]
+#pragma warning disable xUnit1010 // The value is not convertible to the method parameter type
+        [InlineData("2017-01-02T03:04:00", "2017-01-02T03:05:00")]
+        [InlineData("2017-01-02T03:04:05", "2017-01-02T03:05:00")]
+        [InlineData("2017-01-02T03:04:59", "2017-01-02T03:05:00")]
+        [InlineData("2017-01-02T03:00:01", "2017-01-02T03:01:00")]
+        [InlineData("2017-01-31T23:59:59", "2017-02-01T00:00:00")]
+#pragma warning restore xUnit1010 // The value is not convertible to the method parameter type
+        public void Every(DateTime from, DateTime expected)
+        {
+            var schedule = Schedule.Every().Minute();
+
+            var result = schedule.Next(from);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/test/OddJob.Tests/Schedules/EverySecondTests.cs
+++ b/test/OddJob.Tests/Schedules/EverySecondTests.cs
@@ -1,0 +1,25 @@
+using System;
+using OddJob.Schedules;
+using Xunit;
+
+namespace OddJob.Tests.Schedules
+{
+    public class EverySecondTests
+    {
+        [Theory]
+#pragma warning disable xUnit1010 // The value is not convertible to the method parameter type
+        [InlineData("2017-01-02T03:04:00", "2017-01-02T03:04:01")]
+        [InlineData("2017-01-02T03:04:05", "2017-01-02T03:04:06")]
+        [InlineData("2017-01-02T03:04:59", "2017-01-02T03:05:00")]
+        [InlineData("2017-01-02T03:00:01", "2017-01-02T03:00:02")]
+#pragma warning restore xUnit1010 // The value is not convertible to the method parameter type
+        public void Every(DateTime from, DateTime expected)
+        {
+            var schedule = Schedule.Every().Second();
+
+            var result = schedule.Next(from);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Making it possible to have `OddJob` schedule jobs based on a schedule

```csharp
var builder = new JobHostBuilder()
    .Add<MyRegularJob>(new EveryMinute())
    .Add<MyHourlyJob>(new EveryHour());

builder.BuildAndRun();
```

Schedules are defined by implementing the `ISchedule` interface. Two basic schedules are shipped, `EveryMinute` and `EveryHour`. New schedules will follow over time, hopefully including a schedule that accepts a `cron` expression.

### Todo

- [x] Exceptions in a job managed on a schedule should be caught and shouldn't cause the application to terminate